### PR TITLE
Add setting for server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ Using default settings:
 
     include 'winntp'
 
-Set all the parameters:
+OR
+
+Set module parameters:
 
     class { 'winntp':
         special_poll_interval      => 1800, # 30 minutes
         ntp_server                 => 'north-america.pool.ntp.org', # can use comma separated list
         max_pos_phase_correction   => 54000, # 15 hours
         max_neg_phase_correction   => 54000, # 15hours
+		run_server                 => true, # act as an ntp source
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,8 @@ class winntp (
   $special_poll_interval    = 900, # 15 minutes
   $ntp_server               = 'north-america.pool.ntp.org,time.windows.com',
   $max_pos_phase_correction = '0xFFFFFFFF', # unlimited
-  $max_neg_phase_correction = '0xFFFFFFFF') {
+  $max_neg_phase_correction = '0xFFFFFFFF',
+  $run_server = true) {
     
   include 'registry'
 
@@ -20,10 +21,14 @@ class winntp (
     notify => Service['w32time'],
   }
 
+  $serve_mode = $run_server ? {
+    true => '5',
+    false => '0'
+  }
   registry_value { 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time\Config\AnnounceFlags':
     ensure => present,
     type   => 'dword',
-    data   => '5',
+    data   => $serve_mode,
     notify => Service['w32time'],
   }
 
@@ -63,3 +68,5 @@ class winntp (
   }
 
 }
+
+dependency 'puppetlabs/registry', '>= 1.0.0'


### PR DESCRIPTION
Don't want to have ntp source enabled on some systems. This adds a parameter to disable the ntp source registry value.

Also added dependency for the `puppetlabs/registry` module.
